### PR TITLE
require node 16 as adapter-core 3.x.x is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/TA2k/ioBroker.intex"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.5.0",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or earlier as npm 7 does not install peerDependencies. So this adapter requires node 16 or newer.